### PR TITLE
RDKB-36640 Do not terminate program if RDK-logger is not used

### DIFF
--- a/src/cimplog-rdk-logger.c
+++ b/src/cimplog-rdk-logger.c
@@ -40,7 +40,7 @@ void __cimplog(const char *module, int level, const char *msg, ...)
         {
             fprintf(stderr, "\nERROR: RDK Logger not integrated for this module !!!\n");
             fprintf(stderr, " Provide cimplog method \"const char *rdk_logger_module_fetch(void)\" to get log prints !!\n");
-	          exit(0); // Not using RDKLogger is an Error. Terminate!
+	          return; // Not using RDKLogger is an Error. Return!
         }
         init_done = 1;
     }

--- a/src/cimplog-rdk-logger.c
+++ b/src/cimplog-rdk-logger.c
@@ -37,6 +37,8 @@ void __cimplog(const char *module, int level, const char *msg, ...)
         rdk_logger_module = rdk_logger_module_fetch();
         if( NULL == rdk_logger_module )
         {
+            //If RDK logger is not integrated, give the information on the 'stderr' to use the weak implementation of
+            //'const char *rdk_logger_module_fetch(void)' method, through which the rdk_logger_module can be obtained.
             fprintf(stderr, "\nERROR: RDK Logger not integrated for this module - '%s' !!!\n",module);
             fprintf(stderr, " Provide cimplog method \"const char *rdk_logger_module_fetch(void)\" to get log prints !!\n");
         }
@@ -52,7 +54,7 @@ void __cimplog(const char *module, int level, const char *msg, ...)
         //If RDK logger module is not defined, use __cimplog_generic() to capture the logs.
         //The logs will be capture to /rdklogs/logs/Consolelog.txt.0 if available or it
         //will be printed on the console(stdout)
-        __cimplog_generic(module, msg, ...);
+        __cimplog_generic(module, msg);
         return;
     }
 

--- a/src/cimplog-rdk-logger.c
+++ b/src/cimplog-rdk-logger.c
@@ -34,21 +34,25 @@ void __cimplog(const char *module, int level, const char *msg, ...)
 
     if( !init_done )
     {
-        RDK_LOGGER_INIT();
         rdk_logger_module = rdk_logger_module_fetch();
         if( NULL == rdk_logger_module )
         {
-            fprintf(stderr, "\nERROR: RDK Logger not integrated for this module !!!\n");
+            fprintf(stderr, "\nERROR: RDK Logger not integrated for this module - '%s' !!!\n",module);
             fprintf(stderr, " Provide cimplog method \"const char *rdk_logger_module_fetch(void)\" to get log prints !!\n");
-	          return; // Not using RDKLogger is an Error. Return!
+        }
+        else
+        {
+            RDK_LOGGER_INIT();
         }
         init_done = 1;
     }
 
     if( NULL == rdk_logger_module )
     {
-        //if RDK logger module is not defined, simple return - dont print.
-        // used when calling module is not interested in log prints
+        //If RDK logger module is not defined, use __cimplog_generic() to capture the logs.
+        //The logs will be capture to /rdklogs/logs/Consolelog.txt.0 if available or it
+        //will be printed on the console(stdout)
+        __cimplog_generic(module, msg, ...);
         return;
     }
 


### PR DESCRIPTION
Instead of calling exit() from cimplog library, use 'return', so that the executable wont exit if rdk-logger is not integrated with the executable